### PR TITLE
net/sched: add action inheritdsfield to skbmod

### DIFF
--- a/include/uapi/linux/tc_act/tc_skbmod.h
+++ b/include/uapi/linux/tc_act/tc_skbmod.h
@@ -19,6 +19,7 @@
 #define SKBMOD_F_SMAC	0x2
 #define SKBMOD_F_ETYPE	0x4
 #define SKBMOD_F_SWAPMAC 0x8
+#define SKBMOD_F_INHERITDSFIELD 0x10
 
 struct tc_skbmod {
 	tc_gen;

--- a/tc/m_skbmod.c
+++ b/tc/m_skbmod.c
@@ -28,10 +28,11 @@
 static void skbmod_explain(void)
 {
 	fprintf(stderr,
-		"Usage:... skbmod {[set <SETTABLE>] [swap <SWAPABLE>]} [CONTROL] [index INDEX]\n"
+		"Usage:... skbmod {[set <SETTABLE>] [swap <SWAPABLE>] [inheritdsfield]} [CONTROL] [index INDEX]\n"
 		"where SETTABLE is: [dmac DMAC] [smac SMAC] [etype ETYPE]\n"
 		"where SWAPABLE is: \"mac\" to swap mac addresses\n"
 		"note: \"swap mac\" is done after any outstanding D/SMAC change\n"
+		"note: inheritdsfield maps DS field to skb->priority\n"
 		"\tDMAC := 6 byte Destination MAC address\n"
 		"\tSMAC := optional 6 byte Source MAC address\n"
 		"\tETYPE := optional 16 bit ethertype\n"
@@ -69,6 +70,9 @@ static int parse_skbmod(struct action_util *a, int *argc_p, char ***argv_p,
 		if (matches(*argv, "skbmod") == 0) {
 			NEXT_ARG();
 			continue;
+		} else if (matches(*argv, "inheritdsfield") == 0) {
+			p.flags |= SKBMOD_F_INHERITDSFIELD;
+			ok += 1;
 		} else if (matches(*argv, "swap") == 0) {
 			NEXT_ARG();
 			continue;
@@ -211,6 +215,9 @@ static int print_skbmod(struct action_util *au, FILE *f, struct rtattr *arg)
 
 	if (p->flags & SKBMOD_F_SWAPMAC)
 		fprintf(f, "swap mac ");
+
+	if (p->flags & SKBMOD_F_INHERITDSFIELD)
+		fprintf(f, "inherit DS field ");
 
 	fprintf(f, "\n\t index %u ref %d bind %d", p->index, p->refcnt,
 		p->bindcnt);


### PR DESCRIPTION
The new action inheritdsfield copies the field DS of
IPv4 and IPv6 packets into skb->priority. This enables
later classification of packets based on the DS field.

Original idea by Jamal Hadi Salim <jhs@mojatatu.com>

Signed-off-by: Qiaobin Fu <qiaobinf@bu.edu>
Reviewed-by: Michel Machado <michel@digirati.com.br>