### PR TITLE
net/sched: add action inheritdsfield to skbedit

### DIFF
--- a/include/uapi/linux/tc_act/tc_skbedit.h
+++ b/include/uapi/linux/tc_act/tc_skbedit.h
@@ -30,6 +30,7 @@
 #define SKBEDIT_F_MARK			0x4
 #define SKBEDIT_F_PTYPE			0x8
 #define SKBEDIT_F_MASK			0x10
+#define SKBEDIT_F_INHERITDSFIELD	0x20
 
 struct tc_skbedit {
 	tc_gen;
@@ -45,6 +46,7 @@ enum {
 	TCA_SKBEDIT_PAD,
 	TCA_SKBEDIT_PTYPE,
 	TCA_SKBEDIT_MASK,
+	TCA_SKBEDIT_FLAGS,
 	__TCA_SKBEDIT_MAX
 };
 #define TCA_SKBEDIT_MAX (__TCA_SKBEDIT_MAX - 1)

--- a/tc/m_skbedit.c
+++ b/tc/m_skbedit.c
@@ -30,16 +30,18 @@
 
 static void explain(void)
 {
-	fprintf(stderr, "Usage: ... skbedit <[QM] [PM] [MM] [PT]>\n"
+	fprintf(stderr, "Usage: ... skbedit <[QM] [PM] [MM] [PT] [IF]>\n"
 		"QM = queue_mapping QUEUE_MAPPING\n"
 		"PM = priority PRIORITY\n"
 		"MM = mark MARK\n"
 		"PT = ptype PACKETYPE\n"
+		"IF = inheritdsfield\n"
 		"PACKETYPE = is one of:\n"
 		"  host, otherhost, broadcast, multicast\n"
 		"QUEUE_MAPPING = device transmit queue to use\n"
 		"PRIORITY = classID to assign to priority field\n"
-		"MARK = firewall mark to set\n");
+		"MARK = firewall mark to set\n"
+		"note: inheritdsfield maps DS field to skb->priority\n");
 }
 
 static void
@@ -60,6 +62,7 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 	unsigned int tmp;
 	__u16 queue_mapping, ptype;
 	__u32 flags = 0, priority, mark;
+	__u64 pure_flags = 0;
 	struct tc_skbedit sel = { 0 };
 
 	if (matches(*argv, "skbedit") != 0)
@@ -111,6 +114,9 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 			}
 			flags |= SKBEDIT_F_PTYPE;
 			ok++;
+		} else if (matches(*argv, "inheritdsfield") == 0) {
+			pure_flags |= SKBEDIT_F_INHERITDSFIELD;
+			ok++;
 		} else if (matches(*argv, "help") == 0) {
 			usage();
 		} else {
@@ -156,6 +162,9 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 	if (flags & SKBEDIT_F_PTYPE)
 		addattr_l(n, MAX_MSG, TCA_SKBEDIT_PTYPE,
 			  &ptype, sizeof(ptype));
+	if (pure_flags != 0)
+		addattr_l(n, MAX_MSG, TCA_SKBEDIT_FLAGS,
+			  &pure_flags, sizeof(pure_flags));
 	addattr_nest_end(n, tail);
 
 	*argc_p = argc;
@@ -171,6 +180,7 @@ static int print_skbedit(struct action_util *au, FILE *f, struct rtattr *arg)
 	__u32 *priority;
 	__u32 *mark;
 	__u16 *queue_mapping, *ptype;
+	__u64 *flags;
 	struct tc_skbedit *p = NULL;
 
 	if (arg == NULL)
@@ -210,6 +220,11 @@ static int print_skbedit(struct action_util *au, FILE *f, struct rtattr *arg)
 			fprintf(f, " ptype otherhost");
 		else
 			fprintf(f, " ptype %d", *ptype);
+	}
+	if (tb[TCA_SKBEDIT_FLAGS] != NULL) {
+		flags = RTA_DATA(tb[TCA_SKBEDIT_FLAGS]);
+		if (*flags & SKBEDIT_F_INHERITDSFIELD)
+			fprintf(f, " inherit DS field ");
 	}
 
 	print_action_control(f, " ", p->action, "");


### PR DESCRIPTION
The new action inheritdsfield copies the field DS of
IPv4 and IPv6 packets into skb->priority. This enables
later classification of packets based on the DS field.

Original idea by Jamal Hadi Salim <jhs@mojatatu.com>

Signed-off-by: Qiaobin Fu <qiaobinf@bu.edu>
Reviewed-by: Michel Machado <michel@digirati.com.br>